### PR TITLE
Debian squeeze (oldstable) support

### DIFF
--- a/debian/squeeze64.erb
+++ b/debian/squeeze64.erb
@@ -29,7 +29,7 @@
             "headless": true,
 
             "iso_url": "http://cdimage.debian.org/mirror/cdimage/archive/6.0.9/amd64/iso-cd/debian-6.0.9-amd64-netinst.iso",
-            "iso_checksum": "8fdb6715228ea90faba58cb84644d296",
+            "iso_checksum": "9b08117cc235f3084948ab75a0f48861",
             "iso_checksum_type": "md5",
 
             "ssh_username": "vagrant",


### PR DESCRIPTION
Adds a config file for Debian Squeeze, for those poor forsaken souls still relying on it.
