### PR TITLE
Adds support for Debian Squeeze (9.1).

### DIFF
--- a/templates/debian/preseed.cfg
+++ b/templates/debian/preseed.cfg
@@ -49,10 +49,14 @@ d-i user-setup/encrypt-home boolean false
 # packages
 tasksel tasksel/first multiselect standard
 #d-i pkgsel/install-language-support boolean false
-d-i pkgsel/include string openssh-server nfs-common curl ntp acpid sudo bzip2 rsync git ca-certificates
+d-i pkgsel/include string openssh-server nfs-common curl ntp acpid sudo \
+  bzip2 rsync git ca-certificates net-tools
 d-i pkgsel/upgrade select full-upgrade
 d-i pkgsel/update-policy select none
 d-i popularity-contest/participate boolean false
+d-i preseed/late_command string sed -i '/^deb cdrom:/s/^/#/' /target/etc/apt/sources.list
+apt-cdrom-setup apt-setup/cdrom/set-first boolean false
+apt-mirror-setup apt-setup/use_mirror boolean true
 postfix postfix/main_mailer_type select No configuration
 
 # boot loader

--- a/templates/debian/stretch64.erb
+++ b/templates/debian/stretch64.erb
@@ -1,0 +1,60 @@
+{
+    "provisioners": [
+        {
+            "type": "shell",
+            "scripts": [
+                "scripts/postinstall.sh",
+                "scripts/vmtools.sh",
+                <%- @scripts.each do |script| -%>
+                "scripts/<%= script %>",
+                <%- end -%>
+                "scripts/purge.sh"
+            ],
+            "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'"
+        }
+    ],
+    "builders": [
+        {
+            "name": "<%= @name %>",
+            "type": "<%= @provider %>-iso",
+            <%- if @provider == "vmware" -%>
+            "guest_os_type": "debian8-64",
+            "tools_upload_flavor": "linux",
+            <%- else -%>
+            "guest_os_type": "Debian_64",
+            <%- end -%>
+            "headless": false,
+
+            "iso_url": "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-9.1.0-amd64-netinst.iso",
+            "iso_checksum": "c9e070074de83aa22e141f59a423e5210a5019b369ef1efe61a2afd44ba8f371",
+            "iso_checksum_type": "sha256",
+
+            "ssh_username": "vagrant",
+            "ssh_password": "vagrant",
+            "ssh_timeout": "15m",
+
+            "http_directory": "templates/debian",
+
+            "boot_command": [
+                "<esc><wait>",
+                "install ",
+                "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg ",
+                "debian-installer=en_US auto=true locale=en_US kbd-chooser/method=us ",
+                "netcfg/get_hostname={{ .Name }} ",
+                "netcfg/get_domain=vagrantup.com ",
+                "fb=false debconf/frontend=noninteractive ",
+                "console-setup/ask_detect=false console-keymaps-at/keymap=us ",
+                "keyboard-configuration/xkb-keymap=us ",
+                "<enter>"
+            ],
+
+            "shutdown_command": "echo 'shutdown -h now' > shutdown.sh; echo 'vagrant'|sudo -S sh 'shutdown.sh'"
+        }
+    ],
+
+    "post-processors": [
+        {
+            "type": "vagrant"
+        }
+    ]
+}


### PR DESCRIPTION
* Adds a template for Debian Squeeze.
* Adds net-tools to the preseed as `ifconfig` is required by VMWare
  Tools.
* Removes the CD-ROM from APT to surpress post-install messages (it's
  not used anyway).