### PR TITLE
Acceptance test for version, w/custom matchers.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,22 +1,29 @@
-#!/usr/bin/env rake
-
 begin
-  require 'bundler/setup'
+  require "bundler/setup"
 rescue LoadError
-  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
+  puts "You must `gem install bundler` and `bundle install` to run rake tasks"
 end
 
-require 'bundler/gem_tasks'
+require "bundler/gem_tasks"
 
 ##
 # Configure the test suite.
 ##
-require 'rspec/core'
-require 'rspec/core/rake_task'
+require "rspec/core"
+require "rspec/core/rake_task"
 
-RSpec::Core::RakeTask.new
+task(:spec).clear
+desc "Run specs other than spec/acceptance"
+RSpec::Core::RakeTask.new("spec") do |task|
+  task.exclude_pattern = "spec/acceptance/**/*_spec.rb"
+  task.verbose = false
+end
 
-##
-# By default, just run the tests.
-##
-task default: :spec
+desc "Run acceptance specs in spec/acceptance"
+RSpec::Core::RakeTask.new("spec:acceptance") do |task|
+  task.pattern = "spec/acceptance/**/*_spec.rb"
+  task.verbose = false
+end
+
+desc "Run the specs and acceptance tests"
+task default: %w(spec spec:acceptance)

--- a/lib/boxes/testing.rb
+++ b/lib/boxes/testing.rb
@@ -1,0 +1,6 @@
+module Boxes
+  module Testing
+    require "boxes/testing/command"
+    require "boxes/testing/matchers"
+  end
+end

--- a/lib/boxes/testing/command.rb
+++ b/lib/boxes/testing/command.rb
@@ -1,0 +1,23 @@
+module Boxes
+  module Testing
+    module Command
+      attr_reader :response
+
+      def run_command(cmd)
+        stdout = `#{cmd}`
+
+        @response = Response.new(cmd, stdout, $?.exitstatus)
+      end
+
+      class Response
+        attr_accessor :cmd, :stdout, :exit_status
+
+        def initialize(cmd, stdout, exit_status)
+          @cmd = cmd
+          @stdout = stdout
+          @exit_status = exit_status
+        end
+      end
+    end
+  end
+end

--- a/lib/boxes/testing/matchers.rb
+++ b/lib/boxes/testing/matchers.rb
@@ -1,0 +1,16 @@
+module Boxes
+  module Testing
+    module Matchers
+      require "boxes/testing/matchers/have_exit_status_matcher"
+      require "boxes/testing/matchers/write_to_stdout_matcher"
+
+      def have_exit_status(status)
+        HaveExitStatusMatcher.new(status)
+      end
+
+      def write_to_stdout(data)
+        WriteToStdoutMatcher.new(data)
+      end
+    end
+  end
+end

--- a/lib/boxes/testing/matchers/base_matcher.rb
+++ b/lib/boxes/testing/matchers/base_matcher.rb
@@ -1,0 +1,21 @@
+module Boxes
+  module Testing
+    module Matchers
+      class BaseMatcher
+        attr_reader :actual, :expected
+
+        # we can't compare to nil, because we might want nil
+        UNDEFINED = Object.new.freeze
+
+        def initialize(expected = UNDEFINED)
+          @expected = expected unless UNDEFINED.equal?(expected)
+        end
+
+        def matches?(actual)
+          @actual = actual
+          match(actual, expected)
+        end
+      end
+    end
+  end
+end

--- a/lib/boxes/testing/matchers/have_exit_status_matcher.rb
+++ b/lib/boxes/testing/matchers/have_exit_status_matcher.rb
@@ -1,0 +1,19 @@
+require "boxes/testing/matchers/base_matcher"
+
+module Boxes
+  module Testing
+    module Matchers
+      class HaveExitStatusMatcher < BaseMatcher
+        def failure_message
+          "expected that `#{actual.cmd}` would exit with #{expected}"
+        end
+
+        private
+
+        def match(actual, expected)
+          expected == actual.exit_status
+        end
+      end
+    end
+  end
+end

--- a/lib/boxes/testing/matchers/write_to_stdout_matcher.rb
+++ b/lib/boxes/testing/matchers/write_to_stdout_matcher.rb
@@ -1,0 +1,23 @@
+require "boxes/testing/matchers/base_matcher"
+
+module Boxes
+  module Testing
+    module Matchers
+      class WriteToStdoutMatcher < BaseMatcher
+        def failure_message
+          "expected that '#{clean(actual.stdout)}' would be #{clean(expected)}"
+        end
+
+        private
+
+        def match(actual, expected)
+          expected == actual.stdout
+        end
+
+        def clean(output)
+          output.gsub(/\n/, '\n')
+        end
+      end
+    end
+  end
+end

--- a/spec/acceptance/user_views_version_spec.rb
+++ b/spec/acceptance/user_views_version_spec.rb
@@ -1,0 +1,10 @@
+require "acceptance_helper"
+
+RSpec.describe "User views version" do
+  it "successfully lists it's version" do
+    run_command("boxes --version")
+
+    expect(response).to have_exit_status(0)
+    expect(response).to write_to_stdout("#{Boxes::VERSION}\n")
+  end
+end

--- a/spec/acceptance_helper.rb
+++ b/spec/acceptance_helper.rb
@@ -1,0 +1,12 @@
+require "boxes/testing"
+
+RSpec.configure do |config|
+  include Boxes::Testing::Matchers
+  include Boxes::Testing::Command
+
+  config.around(:each) do |example|
+    Dir.chdir("spec/tmp") do
+      example.run
+    end
+  end
+end

--- a/spec/boxes/testing/command_spec.rb
+++ b/spec/boxes/testing/command_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+require "boxes/testing/command"
+
+RSpec.describe Boxes::Testing::Command do
+  include described_class
+
+  describe "#run_command" do
+    context "with output" do
+      it "returns the result of stdout" do
+        run_command("echo 'Hello World!'")
+
+        expect(response).to have_attributes(cmd: "echo 'Hello World!'",
+                                            stdout: "Hello World!\n",
+                                            exit_status: 0)
+      end
+    end
+
+    context "with an exit status" do
+      it "returns the custom exit code" do
+        run_command("exit 1")
+
+        expect(response).to have_attributes(cmd: "exit 1",
+                                            stdout: "",
+                                            exit_status: 1)
+      end
+    end
+  end
+end

--- a/spec/boxes/testing/matchers/have_exit_status_matcher_spec.rb
+++ b/spec/boxes/testing/matchers/have_exit_status_matcher_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+require "boxes/testing"
+
+RSpec.describe Boxes::Testing::Matchers::HaveExitStatusMatcher do
+  context "when an exit status matches" do
+    it "passes" do
+      expected = mock_command(status: 10)
+
+      instance = described_class.new(10)
+      outcome = instance.matches?(expected)
+
+      expect(outcome).to be(true)
+    end
+  end
+
+  context "when an exit status is different" do
+    it "fails with a message" do
+      expected = mock_command(cmd: "cmd", status: 10)
+
+      instance = described_class.new(0)
+      outcome = instance.matches?(expected)
+
+      expect(outcome).to be(false)
+      expect(instance.failure_message).to eq(
+        "expected that `cmd` would exit with 0",
+      )
+    end
+  end
+
+  def mock_command(cmd: nil, status: nil)
+    double("Command::Response", cmd: cmd, exit_status: status)
+  end
+end

--- a/spec/boxes/testing/matchers/write_to_stdout_matcher_spec.rb
+++ b/spec/boxes/testing/matchers/write_to_stdout_matcher_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+require "boxes/testing"
+
+RSpec.describe Boxes::Testing::Matchers::WriteToStdoutMatcher do
+  context "when the output matches" do
+    it "passes" do
+      expected = mock_command(stdout: "Hello World!\n")
+
+      instance = described_class.new("Hello World!\n")
+      outcome = instance.matches?(expected)
+
+      expect(outcome).to be(true)
+    end
+  end
+
+  context "when the output is different" do
+    it "fails with a message" do
+      expected = mock_command(stdout: "Hello!\n")
+
+      instance = described_class.new("Hello World!\n")
+      outcome = instance.matches?(expected)
+
+      expect(outcome).to be(false)
+      expect(instance.failure_message).to eq(
+        "expected that 'Hello!\\n' would be Hello World!\\n",
+      )
+    end
+  end
+
+  def mock_command(cmd: nil, stdout: nil)
+    double("Command::Response", cmd: cmd, stdout: stdout)
+  end
+end


### PR DESCRIPTION
This brings the first RSpec based acceptance test, focusing on
`--version`.

* Runs inside `spec/tmp`.
* Split from the main specs with Rake.
* Provides the `run_command` method inside RSpec.
* …which sets `response` as an object with the command response.
* Provides `write_to_stdout` and `have_exit_status` matchers.
* Implements a simple acceptance test for `--version`.