### PR TITLE
Fix Shell Path Expansion Bug

### DIFF
--- a/spec/boxes/subprocess_spec.rb
+++ b/spec/boxes/subprocess_spec.rb
@@ -1,7 +1,10 @@
 require 'spec_helper'
 
 describe Boxes::Subprocess do
-  let(:command) { "spec/support/subprocess_command.rb" }
+  let(:command) do
+    File.expand_path("../../support/subprocess_command.sh", __FILE__).
+      shellescape
+  end
 
   it 'runs a command and yields a block' do
     expect { |b| Boxes::Subprocess.run(command, &b) }.to yield_control

--- a/spec/support/subprocess_command.rb
+++ b/spec/support/subprocess_command.rb
@@ -1,7 +1,0 @@
-#!/usr/bin/env ruby
-
-STDOUT.puts 'A happy output.'
-
-STDERR.puts 'An unhappy output.'
-
-exit 5

--- a/spec/support/subprocess_command.sh
+++ b/spec/support/subprocess_command.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+echo "A happy output."
+
+>&2 echo "An unhappy output."
+
+exit 5


### PR DESCRIPTION
* Replaces the Ruby example command with one in Shell.
* Fixes a bug with expansion if the tests are run in a directory with special characters.