### PR TITLE
Add ruby 2.1.10 to the list of Rubies.

### DIFF
--- a/scripts/ruby.sh
+++ b/scripts/ruby.sh
@@ -27,6 +27,7 @@ cd ruby-install-$rubyinstall_version/
 make install
 
 # install a set of recent MRI Rubies.
+ruby-install ruby 2.1.10
 ruby-install ruby 2.2.9
 ruby-install ruby 2.3.6
 ruby-install ruby 2.4.3


### PR DESCRIPTION
This brings the set of Rubies inline with the ruby-lang.org …even though
it's EOL.

https://github.com/ruby/www.ruby-lang.org/blob/master/_data/downloads.yml