### PR TITLE
Ubuntu Bionic (18.04) support.

### DIFF
--- a/templates/ubuntu/bionic64.erb
+++ b/templates/ubuntu/bionic64.erb
@@ -1,0 +1,64 @@
+{
+    "provisioners": [
+        {
+            "type": "shell",
+            "scripts": [
+                "scripts/postinstall.sh",
+                "scripts/vmtools.sh",
+                <%- @scripts.each do |script| -%>
+                "scripts/<%= script %>",
+                <%- end -%>
+                "scripts/purge.sh"
+            ],
+            "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'"
+        }
+    ],
+
+    "builders": [
+        {
+            "name": "<%= @name %>",
+            "type": "<%= @provider %>-iso",
+            <%- if @provider == "vmware" -%>
+            "guest_os_type": "ubuntu-64",
+            "tools_upload_flavor": "linux",
+            <%- else -%>
+            "guest_os_type": "Ubuntu_64",
+            <%- end -%>
+            "headless": true,
+
+            "iso_url": "http://cdimage.ubuntu.com/ubuntu/releases/bionic/release/ubuntu-18.04-server-amd64.iso",
+            "iso_checksum": "a7f5c7b0cdd0e9560d78f1e47660e066353bb8a79eb78d1fc3f4ea62a07e6cbc",
+            "iso_checksum_type": "sha256",
+
+            "ssh_username": "vagrant",
+            "ssh_password": "vagrant",
+            "ssh_timeout": "15m",
+
+            "http_directory": "templates/ubuntu",
+
+            "boot_command": [
+                "<enter><wait><f6><esc><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+                "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+                "/install/vmlinuz noapic ",
+                "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg ",
+                "debian-installer=en_US auto locale=en_US kbd-chooser/method=us ",
+                "hostname={{ .Name }} ",
+                "fb=false debconf/frontend=noninteractive ",
+                "keyboard-configuration/modelcode=SKIP keyboard-configuration/layout=USA ",
+                "keyboard-configuration/variant=USA console-setup/ask_detect=false ",
+                "grub-installer/bootdev=/dev/sda ",
+                "initrd=/install/initrd.gz -- <enter>"
+            ],
+
+            "shutdown_command": "echo 'shutdown -P now' > shutdown.sh; echo 'vagrant'|sudo -S sh 'shutdown.sh'"
+        }
+    ],
+
+    "post-processors": [
+        {
+            "type": "vagrant"
+        }
+    ]
+}

--- a/templates/ubuntu/preseed.cfg
+++ b/templates/ubuntu/preseed.cfg
@@ -49,7 +49,7 @@ d-i user-setup/encrypt-home boolean false
 # packages
 tasksel tasksel/first multiselect standard, ubuntu-server
 d-i pkgsel/install-language-support boolean false
-d-i pkgsel/include string openssh-server nfs-common curl git-core
+d-i pkgsel/include string openssh-server nfs-common curl git-core python
 d-i pkgsel/upgrade select full-upgrade
 d-i pkgsel/update-policy select none
 postfix postfix/main_mailer_type select No configuration


### PR DESCRIPTION
* Adds a Bionic template based on the one from Xenial.
* Bionic no longer ships with Python by default, so adds to the preseed
  as we use it in `scripts/chef.sh`.