### PR TITLE
Disable predictive network interface naming.

### DIFF
--- a/scripts/purge.sh
+++ b/scripts/purge.sh
@@ -6,25 +6,6 @@
 # Based on: https://gist.github.com/adrienbrault/3775253
 ##
 
-# tidy up DCHP leases
-echo "Cleaning up dhcp..."
-rm /var/lib/dhcp/*
-
-# make sure Udev doesn't block our network
-# except on systemd systems where this isn't used
-# http://6.ptmc.org/?p=164
-case $(lsb_release -cs) in
-    "wily" | "xenial")
-    ;;
-    *)
-    echo "Cleaning up udev..."
-    rm /etc/udev/rules.d/70-persistent-net.rules
-    mkdir /etc/udev/rules.d/70-persistent-net.rules
-    rm -rf /dev/.udev/
-    rm /lib/udev/rules.d/75-persistent-net-generator.rules
-    ;;
-esac
-
 # clean up apt
 echo "Cleaning up apt..."
 apt-get -qy autoremove


### PR DESCRIPTION
* Only on `systemd` systems (Debian 8 and up, Ubuntu 16.04 and up).
* Only disable `udev` networking rules on pre-`systemd` systems (to
  avoid previous names sticking around on network re-configuration).

Ubuntu 18.04 introduces `netplan`, a centralised way to configure
network interfaces. This is much easier to work with if we use the old
`eth` based naming.