### PR TITLE
Support for Ubuntu 20.04

### DIFF
--- a/scripts/vmtools.sh
+++ b/scripts/vmtools.sh
@@ -4,6 +4,10 @@
 # Configure the relevant VM tools for this builder.
 ##
 
+distribution=$(lsb_release -si)
+version=$(lsb_release -sr)
+major_version=$(echo "$version" | awk -F . '{print $1}')
+
 case $PACKER_BUILDER_TYPE in
     'virtualbox-iso')
         echo "Installing VirtualBox Guest Additions..."
@@ -15,17 +19,23 @@ case $PACKER_BUILDER_TYPE in
         rm -f /home/vagrant/VBoxGuestAdditions.iso
     ;;
     'vmware-iso')
-        echo "Installing VMware Tools..."
-        apt-get -qy install fuse
-        mkdir -p /mnt/cdrom
-        mount -o loop /home/vagrant/linux.iso /mnt/cdrom
+				if [ "$distribution" = 'Ubuntu' ]; then
+					if [ "$major_version" -le "19" ]; then
+						echo "Installing VMware Tools..."
+						apt-get -qy install fuse
+						mkdir -p /mnt/cdrom
+						mount -o loop /home/vagrant/linux.iso /mnt/cdrom
 
-        cd /tmp
-        tar -zxpf /mnt/cdrom/VMwareTools-*.tar.gz -C /tmp/
-        /tmp/vmware-tools-distrib/vmware-install.pl --force-install --default
+						cd /tmp
+						tar -zxpf /mnt/cdrom/VMwareTools-*.tar.gz -C /tmp/
+						/tmp/vmware-tools-distrib/vmware-install.pl --force-install --default
 
-        umount /mnt/cdrom
-        rm -f /home/vagrant/linux.iso
+						umount /mnt/cdrom
+						rm -f /home/vagrant/linux.iso
+					else
+						echo "Skipping installing VMware Tools because open-vm-tools works..."
+					fi
+				fi
     ;;
     *)
         printf "Nothing to do for the %s builder type.\n" $PACKER_BUILDER_TYPE

--- a/templates/ubuntu/focal64.erb
+++ b/templates/ubuntu/focal64.erb
@@ -1,0 +1,53 @@
+{
+    "provisioners": [
+        {
+            "type": "shell",
+            "scripts": [
+                <%= ["postinstall.sh", "vmtools.sh", @scripts].flatten.map { |i| "\"scripts/#{i}\"" }.join(", ") %>
+            ],
+            "execute_command": "echo 'vagrant' | {{ .Vars }} sudo -E -S bash '{{ .Path }}'"
+        }
+    ],
+
+    "builders": [
+        {
+            "name": "<%= @name %>",
+            "type": "<%= @provider %>-iso",
+            <%- if @provider == "vmware" -%>
+            "guest_os_type": "ubuntu-64",
+            "tools_upload_flavor": "linux",
+            <%- else -%>
+            "guest_os_type": "Ubuntu_64",
+            <%- end -%>
+            "headless": true,
+
+            "memory": 1024,
+
+            "iso_url": "http://releases.ubuntu.com/20.04/ubuntu-20.04-live-server-amd64.iso",
+            "iso_checksum": "caf3fd69c77c439f162e2ba6040e9c320c4ff0d69aad1340a514319a9264df9f",
+            "iso_checksum_type": "sha256",
+
+            "ssh_username": "vagrant",
+            "ssh_password": "vagrant",
+            "ssh_handshake_attempts": "50",
+            "ssh_timeout": "10m",
+
+            "http_directory": "templates/ubuntu",
+
+            "boot_wait": "5s",
+            "boot_command": [
+              "<enter><enter><f6><esc><wait> ",
+              "autoinstall ds=nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/",
+              "<enter>"
+            ],
+
+            "shutdown_command": "echo 'shutdown -P now' > shutdown.sh; echo 'vagrant'|sudo -S sh 'shutdown.sh'"
+        }
+    ],
+
+    "post-processors": [
+        {
+            "type": "vagrant"
+        }
+    ]
+}

--- a/templates/ubuntu/user-data
+++ b/templates/ubuntu/user-data
@@ -1,0 +1,17 @@
+#cloud-config
+autoinstall:
+  version: 1
+  identity:
+    hostname: unassigned-hostname
+    username: vagrant
+    password: '$6$IrzMz/ehZN.wfW49$JU36Dv3xOxkAHQTECBjDaSGNyLndBT5JTkL3CC.hLEEw3TBAOJCWanP0meOPqaMwabmIAAICuG288JBK8HdMP.'
+  network:
+    network:
+      version: 2
+      ethernets:
+        ens33: {dhcp4: true, dhcp-identifier: mac}
+  ssh:
+    install-server: true
+  late-commands:
+    - sed -i 's/^#*\(send dhcp-client-identifier\).*$/\1 = hardware;/' /target/etc/dhcp/dhclient.conf
+    - 'sed -i "s/dhcp4: true/&\n      dhcp-identifier: mac/" /target/etc/netplan/00-installer-config.yaml'


### PR DESCRIPTION
* Introduces the new method installing using subiquity and cloud-init,
* Increases the memory to 1GB for installer compatibility,
* Sets the SSH timeout and handshake limits to be high enough to be
   clear of the installer race condition.
* purge now breaks the VM disk, so this is gone,
* open-vm-tools is included for VMware, but we still need to install
  VirtualBox Additions

See: https://nickcharlton.net/posts/automating-ubuntu-2004-installs-with-packer.html